### PR TITLE
Updated tcp_handshake_duration 

### DIFF
--- a/zeek/tcp_rtt.zeek
+++ b/zeek/tcp_rtt.zeek
@@ -47,11 +47,9 @@ redef record connection +=
 
 event connection_first_ACK(c: connection)
 {
+    #Currently not accounting for TCP Fast open but will do so in future patches. 
     #check for "normal" tcp handshake (weeds out some connections where RTT can't be calculated accurately):
-    if (c$orig$num_pkts == 1 && c$resp$num_pkts == 1 && c$history == "ShA")
-    {
-        c$tcp_handshake_duration = network_time() - c$start_time;
-    }
+    c$tcp_handshake_duration = network_time() - c$start_time;
 }
 
 event connection_state_remove(c: connection)


### PR DESCRIPTION
The tcp_handshake_duration has had its if-statement removed to better support the idea behind the variable name and to now have the variable be calculated in certain network architectures that are non-standard. 